### PR TITLE
Handle IGNORE trap handlers

### DIFF
--- a/lib/multitrap/trap.rb
+++ b/lib/multitrap/trap.rb
@@ -45,7 +45,7 @@ module Multitrap
 
       prev_trap_handler = @original_trap.call(signal) do |signo|
         @trap_list[signal].reverse_each do |trap_handler|
-          trap_handler.call(signo || Signal.list[signal])
+          trap_handler.call(signo || Signal.list[signal]) if trap_handler.respond_to?(:call)
         end
       end
 

--- a/spec/multitrap_spec.rb
+++ b/spec/multitrap_spec.rb
@@ -153,6 +153,17 @@ describe Multitrap::Trap do
       wait_for(d).to eq([2, 1, 0])
     end
 
+    it 'ignores IGNORE trap commands' do
+      e = []
+
+      3.times do |_i|
+        trap(SIGNAL, 'IGNORE')
+      end
+
+      Process.kill(SIGNAL, $$)
+      wait_for(e).to eq([])
+    end
+
     it "ignores block if proc is given" do
       e = []
 


### PR DESCRIPTION
Thanks for this library! 

When `Signal.trap` is called with a 2nd string argument of `IGNORE`, this library fails:

```
17:14:23 web.1    | undefined method `call' for "IGNORE":String (NoMethodError)
17:14:23 web.1    | 	from /Users/shaun.mccormick/.rvm/gems/ruby-2.4.4/gems/multitrap-0.1.0/lib/multitrap/trap.rb:47:in `reverse_each'
17:14:23 web.1    | 	from /Users/shaun.mccormick/.rvm/gems/ruby-2.4.4/gems/multitrap-0.1.0/lib/multitrap/trap.rb:47:in `block in store_trap'
17:14:23 web.1    | 	from /Users/shaun.mccormick/.rvm/gems/ruby-2.4.4/gems/puma-3.12.1/lib/puma/cluster.rb:308:in `join'
17:14:23 web.1    | 	from /Users/shaun.mccormick/.rvm/gems/ruby-2.4.4/gems/puma-3.12.1/lib/puma/cluster.rb:308:in `worker'
17:14:23 web.1    | 	from /Users/shaun.mccormick/.rvm/gems/ruby-2.4.4/gems/puma-3.12.1/lib/puma/cluster.rb:139:in `block (2 levels) in spawn_workers'
17:14:23 web.1    | 	from /Users/shaun.mccormick/.rvm/gems/ruby-2.4.4/gems/puma-3.12.1/lib/puma/cluster.rb:139:in `fork'
```

Adding a check for the responsiveness of the handler to `.call` fixes this.
